### PR TITLE
Use monospace font in code editor.

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -214,6 +214,7 @@ section footer {
 /* Codemirror overrides */
 .CodeMirror {
   font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+  font-size: 13px;
   padding: var(--default-padding) 0;
   height: 100%;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -213,7 +213,7 @@ section footer {
 
 /* Codemirror overrides */
 .CodeMirror {
-  font-family: inherit;
+  font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
   padding: var(--default-padding) 0;
   height: 100%;
 }


### PR DESCRIPTION
Now code uses monospace font:
(before)
<img width="634" alt="screen shot 2017-12-01 at 15 11 37" src="https://user-images.githubusercontent.com/8555194/33486368-0bd9c8f6-d6aa-11e7-80b0-b8446fda63fb.png">

(after)
<img width="632" alt="screen shot 2017-12-01 at 15 11 44" src="https://user-images.githubusercontent.com/8555194/33486376-1419f450-d6aa-11e7-9fdc-fccf75759aa6.png">
