### PR TITLE
Change the editor font to monospace

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -214,7 +214,7 @@ section footer {
 
 /* Codemirror overrides */
 .CodeMirror {
-  font-family: inherit;
+  font-family: 'Menlo', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
   padding: var(--default-padding) 0;
   height: 100%;
 }


### PR DESCRIPTION
The `CodeMirror` editor currently `inherits` the `font-family` which is set to `"Product Sans", sans-serif;`. This sets it to a monospace font.